### PR TITLE
Fix various Slick 3.0 deprecation warnings

### DIFF
--- a/src/main/scala/CaseClassMapping.scala
+++ b/src/main/scala/CaseClassMapping.scala
@@ -2,6 +2,7 @@ import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
 import slick.driver.H2Driver.api._
+import slick.profile.SqlProfile.ColumnOption.NotNull
 
 object CaseClassMapping extends App {
 
@@ -30,7 +31,7 @@ class Users(tag: Tag) extends Table[User](tag, "USERS") {
   // Auto Increment the id primary key column
   def id = column[Int]("ID", O.PrimaryKey, O.AutoInc)
   // The name can't be null
-  def name = column[String]("NAME", O.NotNull)
+  def name = column[String]("NAME", NotNull)
   // the * projection (e.g. select * ...) auto-transforms the tupled
   // column values to / from a User
   def * = (name, id.?) <> (User.tupled, User.unapply)

--- a/src/main/scala/QueryActions.scala
+++ b/src/main/scala/QueryActions.scala
@@ -20,7 +20,7 @@ object QueryActions extends App {
 
     // Define a pre-compiled parameterized query for reading all key/value
     // pairs up to a given key.
-    val upTo = Compiled { k: Column[Int] =>
+    val upTo = Compiled { k: Rep[Int] =>
       dict.filter(_.key <= k).sortBy(_.key)
     }
 
@@ -30,7 +30,7 @@ object QueryActions extends App {
     Await.result(db.run(DBIO.seq(
 
       // Create the dictionary table and insert some data
-      dict.ddl.create,
+      dict.schema.create,
       dict ++= Seq(1 -> "a", 2 -> "b", 3 -> "c", 4 -> "d", 5 -> "e"),
 
       upTo(3).result.map { r =>
@@ -69,5 +69,5 @@ object QueryActions extends App {
       println("- " + v)
     }, Duration.Inf)
 
-  } finally db.close
+  } finally db.close()
 }


### PR DESCRIPTION
Fix a few deprecation warnings, and a warning about parameterless `db.close`. Not sure if this branch is actively maintained, or if it's elsewhere, but just in case.