### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 This is a template for [Typesafe Activator](http://typesafe.com/platform/getstarted).
+
+There are separate branches in this repository (and separate Activator template catalog entries pointing to them) for each major Slick version. The master branch is the "legacy" 2.0 version. Switch the branch corresponding to the slick version you want to see the template for.


### PR DESCRIPTION
Give an indication on the README that you have to switch branches to see templates for different slick versions.

The links of this page https://www.lightbend.com/activator/template/hello-slick-3.1 to this github suggest they are trying to link to the relevant branch (i.e. https://github.com/typesafehub/activator-hello-slick#slick-3.1), but that doesn't change branch on github. The url should be https://github.com/typesafehub/activator-hello-slick/tree/slick-3.1 . I don't how to submit changes to the lightbend activator documentation page.
